### PR TITLE
FEAT: Parallel rule execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ test
     - Check that README.md is updated based on README_template.md.
 README.md
     Render README.md based on README_template.md.
-dist/gird-1.4.2-py3-none-any.whl
+dist/gird-1.5.0-py3-none-any.whl
     Build distribution packages for the current version.
 publish
     Publish packages of the current version to PyPI.

--- a/gird/common.py
+++ b/gird/common.py
@@ -36,3 +36,13 @@ class Rule:
     deps: Optional[List[Dependency]] = None
     recipe: Optional[List[SubRecipe]] = None
     help: Optional[str] = None
+
+
+class Parallelism(int):
+    # Integer type to control parallel rule execution. See the special constants
+    # PARALLELISM_OFF & PARALLELISM_UNLIMITED_JOBS.
+    pass
+
+
+PARALLELISM_OFF = Parallelism(0)
+PARALLELISM_UNLIMITED_JOBS = Parallelism(-1)

--- a/gird/gird.py
+++ b/gird/gird.py
@@ -1,21 +1,26 @@
 """Main module with CLI."""
 
 import argparse
+import os
 import pathlib
 import subprocess
 import sys
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Optional, Tuple
 
-from .common import Rule
+from .common import PARALLELISM_OFF, PARALLELISM_UNLIMITED_JOBS, Parallelism, Rule
 from .girdfile import import_girdfile
 from .girdpath import get_gird_path_run, get_gird_path_tmp, init_gird_path
 from .makefile import format_target, write_makefiles
 
-# Name of the subcommand to list all rules.
+# Name of the subcommand that lists all rules.
 SUBCOMMAND_LIST = "list"
 
 
-def parse_args_import_rules() -> Tuple[List[Rule], str]:
+def parse_args_import_rules() -> Tuple[
+    List[Rule],
+    str,
+    Optional[Parallelism],
+]:
     """Parse CLI arguments and import Rules from a girdfile. Call sys.exit() in
     case of an error or based on CLI arguments.
 
@@ -26,6 +31,9 @@ def parse_args_import_rules() -> Tuple[List[Rule], str]:
     subcommand
         The name of the subcommand to be run. Either SUBCOMMAND_LIST or
         the name of a rule to be run.
+    parallelism
+        The selected parallelism state. Will be None if subcommand is
+        SUBCOMMAND_LIST.
     """
     current_dir = pathlib.Path.cwd()
 
@@ -41,7 +49,7 @@ def parse_args_import_rules() -> Tuple[List[Rule], str]:
         "-f",
         "--girdfile",
         type=pathlib.Path,
-        default=current_dir / "girdfile.py",
+        default=None,
         help="Path to the file with rule definitions. Defaults to ./girdfile.py.",
     )
 
@@ -62,58 +70,129 @@ def parse_args_import_rules() -> Tuple[List[Rule], str]:
 
     args_init, args_rest = parser.parse_known_args()
 
+    girdfile_arg: Optional[pathlib.Path] = args_init.girdfile
+    girdfile_to_import: pathlib.Path = girdfile_arg or current_dir / "girdfile.py"
+
     # Initialize & import Rules from girdfile.
-    init_gird_path(args_init.girdpath, args_init.girdfile)
+    init_gird_path(args_init.girdpath, girdfile_to_import)
     try:
-        rules = import_girdfile(args_init.girdfile)
+        rules = import_girdfile(girdfile_to_import)
+        girdfile_import_error = None
     except ImportError as e:
-        print_message(e.args[0], stderr=True)
-        sys.exit(1)
+        girdfile_import_error = ImportError(*e.args)
+        rules = []
+
+    helptext_help = "Show this help message and exit."
 
     # Define --help here to be parsed after subparsers are completely defined.
     group_options.add_argument(
         "-h",
         "--help",
         action="help",
-        help="Show this help message and exit.",
+        help=helptext_help,
     )
 
-    help_rules = "one of " + ", ".join(
-        "'" + str(format_target(rule.target)) + "'" for rule in rules
-    )
+    if len(rules) > 0:
+        rules_str = (
+            f" Rules defined in {os.path.relpath(girdfile_to_import, current_dir)} are: "
+            + ", ".join("'" + str(format_target(rule.target)) + "'" for rule in rules)
+            + "."
+        )
+    else:
+        rules_str = ""
+
     subparsers = parser.add_subparsers(
         title="subcommands",
         dest="subcommand",
         metavar=f"{{{SUBCOMMAND_LIST}, rule}}",
-        help=f"List all rules or run a single rule ({help_rules}).",
+        help=(
+            "List all rules or run a single rule. For rule-specific help, run "
+            f"'gird [options] {{rule}} --help'.{rules_str}"
+        ),
     )
 
     subparsers.add_parser(SUBCOMMAND_LIST, add_help=False)
 
     for rule in rules:
-        subparsers.add_parser(str(format_target(rule.target)), add_help=False)
+        subparser_rule = subparsers.add_parser(
+            str(format_target(rule.target)),
+            description=rule.help,
+            add_help=False,
+        )
+
+        subparser_rule.add_argument(
+            "-j",
+            "--jobs",
+            type=Parallelism,
+            nargs="?",
+            default=PARALLELISM_OFF,
+            const=PARALLELISM_UNLIMITED_JOBS,
+            help=(
+                "Number of jobs for parallel execution (off by default). If no "
+                "integer argument is given, set no limit for the number of "
+                "parallel jobs. Output will be buffered per each target, if "
+                "the used Make implementation supports the feature. (E.g., "
+                "colored output may be turned off by some programs.) Recipes "
+                "that require input may fail due to temporary input stream "
+                "invalidation."
+            ),
+        )
+        subparser_rule.add_argument(
+            "-h",
+            "--help",
+            action="help",
+            help=helptext_help,
+        )
 
     args_rest = parser.parse_args(args_rest)
     subcommand = args_rest.subcommand
 
-    if subcommand is None:
+    if subcommand is not None and subcommand != SUBCOMMAND_LIST:
+        parallelism = args_rest.jobs
+    else:
+        parallelism = None
+
+    if girdfile_import_error is not None:
+        if girdfile_arg is not None or subcommand == SUBCOMMAND_LIST:
+            print_message(girdfile_import_error.args[0], use_stderr=True)
+            sys.exit(1)
+
+    if len(rules) == 0 or subcommand is None:
         parser.print_help()
         sys.exit(0)
 
-    return rules, subcommand
+    return rules, subcommand, parallelism
 
 
-def print_message(message: str, stderr: bool = False):
-    """Print message about, e.g., rule's execution progress. If stderr=True,
+def print_message(message: str, use_stderr: bool = False):
+    """Print message about, e.g., rule's execution progress. If use_stderr=True,
     use sys.stderr instead of sys.stdout.
     """
-    file = sys.stderr if stderr else sys.stdout
-    print(f"gird: {message}", file=file, flush=True)
+    file = sys.stderr if use_stderr else sys.stdout
+    message_parts = ["gird:"]
+    if use_stderr:
+        message_parts.append("Error:")
+    message_parts.append(message)
+    print(" ".join(message_parts), file=file, flush=True)
 
 
-def run_rule(rules: Iterable[Rule], rule: str):
-    """Run a rule. Call sys.exit(returncode) in case of non-zero return code."""
-    write_makefiles(rules)
+def run_rule(
+    rules: Iterable[Rule],
+    rule: str,
+    parallelism: Parallelism,
+):
+    """Run a rule. Call sys.exit(returncode) in case of non-zero return code.
+
+    Parameters
+    ----------
+    rules
+        Rules defined by a girdfile.
+    rule
+        The rule to run.
+    parallelism
+        Parallelism state.
+    """
+    write_makefiles(rules, parallelism)
 
     gird_path_tmp = get_gird_path_tmp()
     gird_path_run = get_gird_path_run()
@@ -140,7 +219,7 @@ def run_rule(rules: Iterable[Rule], rule: str):
                 f"Execution of rule '{rule}' returned with error. Possible "
                 f"output & error messages should be visible above."
             ),
-            stderr=True,
+            use_stderr=True,
         )
         sys.exit(process.returncode)
     else:
@@ -157,8 +236,8 @@ def list_rules(rules: Iterable[Rule]):
 
 
 def main():
-    rules, subcommand = parse_args_import_rules()
+    rules, subcommand, parallelism = parse_args_import_rules()
     if subcommand == SUBCOMMAND_LIST:
         list_rules(rules)
     else:
-        run_rule(rules, subcommand)
+        run_rule(rules, subcommand, parallelism)

--- a/gird/rule.py
+++ b/gird/rule.py
@@ -22,7 +22,7 @@ def rule(
     ] = None,
     help: Optional[str] = None,
 ) -> Rule:
-    """Define & register a Gird Rule.
+    """Define & register a Rule.
 
     Parameters
     ----------
@@ -141,7 +141,7 @@ def rule(
             recipe = [recipe]
         recipe = list(recipe)
 
-    main_rule = Rule(
+    rule = Rule(
         target=target,
         deps=deps,
         recipe=recipe,
@@ -149,6 +149,6 @@ def rule(
     )
 
     if GIRDFILE_CONTEXT.rules is not None:
-        GIRDFILE_CONTEXT.rules.append(main_rule)
+        GIRDFILE_CONTEXT.rules.append(rule)
 
-    return main_rule
+    return rule

--- a/gird/utils.py
+++ b/gird/utils.py
@@ -3,6 +3,7 @@
 import datetime
 import inspect
 import pathlib
+import subprocess
 from typing import Callable
 
 
@@ -28,3 +29,12 @@ def get_python_function_shell_command(
 
 def get_path_modified_time(path: pathlib.Path) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(path.stat().st_mtime_ns // 1e9)
+
+
+def get_make_support_output_sync() -> bool:
+    """Test whether Make supports the '--output-sync' parameter."""
+    process = subprocess.run(["make", "--help"], text=True, stdout=subprocess.PIPE)
+    return "--output-sync" in process.stdout
+
+
+MAKE_SUPPORT_OUTPUT_SYNC = get_make_support_output_sync()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gird"
-version = "1.4.2"
+version = "1.5.0"
 description = "Make-like build tool & task runner for Python"
 authors = ["Tuukka Ruhanen <tuukka.t.ruhanen@gmail.com>"]
 homepage = "https://github.com/gird-dev/gird"

--- a/test/functional/test_cli/test_cli.py
+++ b/test/functional/test_cli/test_cli.py
@@ -24,20 +24,30 @@ def init_cli_test(pytest_tmp_path) -> List[str]:
 
 
 def test_cli_no_girdfile(tmp_path, run):
-    """Test functionality with no available girdfile."""
+    """Test functionality with nonexistent girdfile given as argument."""
     girdfile_name = "nonexistent-girdfile.py"
     process = run(
         tmp_path,
         ["gird", "--girdfile", girdfile_name],
         raise_on_error=False,
     )
+    assert process.returncode == 1
     assert process.stderr.startswith(
-        f"gird: Could not import girdfile '{girdfile_name}'."
+        f"gird: Error: Could not import girdfile '{girdfile_name}'."
     )
 
 
 def test_cli_help(tmp_path, run):
     """Test CLI argument --help."""
+    # Test with nonexistent girdfile.
+    process = run(
+        tmp_path,
+        ["gird", "--help"],
+        raise_on_error=False,
+    )
+    assert process.stdout.startswith("usage: gird")
+
+    # Test with an existing girdfile.
     args = init_cli_test(tmp_path)
     args.append("--help")
     process = run(
@@ -49,6 +59,15 @@ def test_cli_help(tmp_path, run):
 
 def test_cli_no_arguments(tmp_path, run):
     """Test CLI with no arguments."""
+    # Test with nonexistent girdfile.
+    process = run(
+        tmp_path,
+        ["gird"],
+        raise_on_error=False,
+    )
+    assert process.stdout.startswith("usage: gird")
+
+    # Test with an existing girdfile.
     args = init_cli_test(tmp_path)
     process = run(
         tmp_path,
@@ -69,6 +88,17 @@ def test_cli_verbose(tmp_path, run):
 
 def test_cli_list(tmp_path, run):
     """Test CLI subcommand 'list'."""
+    # Test with nonexistent girdfile.
+    process = run(
+        tmp_path,
+        ["gird", "list"],
+        raise_on_error=False,
+    )
+    assert process.returncode == 1
+    assert process.stderr.startswith(
+        "gird: Error: Could not import girdfile 'girdfile.py'."
+    )
+
     args = init_cli_test(tmp_path)
     args.append("list")
     process = run(
@@ -110,8 +140,9 @@ def test_cli_run_rule_with_error(tmp_path, run):
         args,
         raise_on_error=False,
     )
+    assert process.returncode == 2
     assert (
         process.stderr.strip()
         .split("\n")[-1]
-        .startswith(f"gird: Execution of rule '{target}' returned with error.")
+        .startswith(f"gird: Error: Execution of rule '{target}' returned with error.")
     )

--- a/test/functional/test_parallel/girdfile.py
+++ b/test/functional/test_parallel/girdfile.py
@@ -1,0 +1,47 @@
+import pathlib
+import time
+
+import gird
+
+TARGET1 = pathlib.Path("target1")
+TARGET2 = pathlib.Path("target2")
+
+
+def create_target(path: pathlib.Path):
+    """Record current time twice in a file. Use time.wait() to make sure the
+    same times, with a precision of on second, couldn't be recorded without
+    parallel execution.
+    """
+    print(f"{path} time0.")
+    time0 = time.time()
+    time.sleep(0.51)
+    print(f"{path} time1.")
+    time1 = time.time()
+    path.write_text(f"{time0}\n{time1}\n")
+    time.sleep(1.01)
+
+
+def create_target1():
+    create_target(TARGET1)
+
+
+def create_target2():
+    create_target(TARGET2)
+
+
+gird.rule(
+    target=TARGET1,
+    recipe=create_target1,
+)
+
+
+gird.rule(
+    target=TARGET2,
+    recipe=create_target2,
+)
+
+
+gird.rule(
+    target=gird.Phony("parallel"),
+    deps=[TARGET1, TARGET2],
+)

--- a/test/functional/test_parallel/test_parallel.py
+++ b/test/functional/test_parallel/test_parallel.py
@@ -1,0 +1,34 @@
+import pathlib
+from typing import Set
+
+from gird.common import PARALLELISM_UNLIMITED_JOBS
+
+TEST_DIR = pathlib.Path(__file__).parent
+
+
+def get_times(path: pathlib.Path) -> Set[int]:
+    """Read the times from a target file with one second precision."""
+    return set(int(round(float(line))) for line in path.read_text().strip().split("\n"))
+
+
+def test_parallel(tmp_path, run_rule):
+    """Test that a recipe is run in parallel."""
+    process = run_rule(
+        pytest_tmp_path=tmp_path,
+        test_dir=TEST_DIR,
+        rule="parallel",
+        parallelism=PARALLELISM_UNLIMITED_JOBS,
+    )
+
+    target1 = tmp_path / "target1"
+    target2 = tmp_path / "target2"
+
+    times1 = get_times(target1)
+    times2 = get_times(target2)
+
+    # Test that recorded times overlap.
+    assert len(times1 & times2) > 0
+
+    # Test that output is buffered, i.e., recipes' output is intact.
+    for target in (target1, target2):
+        assert f"{target.name} time0.\n{target.name} time1.\n" in process.stdout


### PR DESCRIPTION
- Parallel rule execution can now be controlled via the CLI by `gird {rule} -j`, similarly to Make.
- Rules now have CLI helptext, shown by `gird {rule} --help`.
- Improved error handling & messages with girdfile import.
- Improved CLI tests.
- Increased the version number to 1.5.0.